### PR TITLE
[claude-experiments] Rewrite nullability.md to match implementation

### DIFF
--- a/Design/nullability.md
+++ b/Design/nullability.md
@@ -6,69 +6,13 @@ Viper so that the verifier can reason about null safety.
 
 [1]: https://github.com/Kotlin/KEEP/blob/3490e847fe51aa6deb869654029a5a514638700e/proposals/kotlin-contracts.md
 
-## Approaches considered
+## Encoding
 
-### Parametric `Nullable[T]` domain
-
-The first approach considered was a parametric Viper domain that wraps values:
-
-```viper
-domain Nullable[T] {
-    function null_val(): Nullable[T]
-    function nullable_of(val: T): Nullable[T]
-    function val_of_nullable(x: Nullable[T]): T
-
-    axiom some_not_null {
-        forall x: T :: nullable_of(x) != null_val()
-    }
-    axiom val_of_nullable_of_val {
-        forall x: T :: val_of_nullable(nullable_of(x)) == x
-    }
-    axiom nullable_of_val_of_nullable {
-        forall x: Nullable[T] ::
-            x != null_val() ==> nullable_of(val_of_nullable(x)) == x
-    }
-}
-```
-
-This gives a clean separation: `T` is the non-nullable type, `Nullable[T]` is
-the nullable wrapper, and `nullable_of`/`val_of_nullable` convert between them.
-
-Drawbacks:
-- **Primitive boxing**: `Int` has no null value in Viper, so `Int?` would need
-  heap boxing. Passing `Int?` as a parameter then requires cloning to avoid
-  aliasing side effects.
-- **Permission reasoning**: accessing the wrapped value requires heap
-  permissions, adding complexity we want to avoid.
-- **Explicit conversion**: every nullable-to-non-nullable transition needs an
-  explicit `val_of_nullable` call, and vice versa.
-
-A prototype of this approach exists in `Domains/Nullable.vpr` (with a companion
-`Casting` domain for type conversions).
-
-### Built-in Viper `null`
-
-A simpler alternative: use Viper's built-in `null` reference directly. A
-function `null_check(x: Any?): Boolean` would translate to:
-
-```viper
-method null_check(x: Ref) returns (ret: Bool)
-    requires x != null ==> acc(x.val)
-    ensures ret <==> x != null
-```
-
-Drawbacks:
-- Requires permission reasoning for field access behind null checks.
-- Primitives still need boxing onto the heap.
-- Conflates Viper's `null` (a `Ref` value) with Kotlin's `null` (a value in
-  any nullable type).
-
-### Unified `Ref` with runtime type tracking (chosen)
-
-The approach adopted is to represent **all** Kotlin values as Viper `Ref`, with
-type information tracked through the [runtime type domain](runtime-type-domain.md).
-Nullable types are handled by a `nullable(t)` type wrapper in the domain,
-rather than by wrapping values.
+All Kotlin values are represented as Viper `Ref`, with type information tracked
+through the [runtime type domain](runtime-type-domain.md). Nullability is
+handled at the type level: a `nullable(t)` wrapper in the domain marks types
+that admit null, and `nullValue()` is a distinguished domain constant
+representing null.
 
 A nullable parameter `x: Int?` is encoded as:
 
@@ -83,13 +27,56 @@ method f(p$x: Ref) returns (ret$0: Ref)
 The value `p$x` is just a `Ref`. The `inhale` establishes that its runtime type
 is a subtype of `Int?`. No boxing, no permissions, no wrapper types.
 
-Advantages over the alternatives:
-- No boxing/unboxing for primitives — injection functions (`intToRef`/`intFromRef`)
-  handle the Viper-level representation transparently.
-- No permission reasoning for null checks — everything is value-level.
-- Smart casts fall out of axioms rather than requiring explicit conversions.
-- Nullable and non-nullable types share the same Viper type (`Ref`), so
-  parameter passing, assignment, and comparison work uniformly.
+Note that `nullValue()` is a domain function, not Viper's built-in `null`. We
+do not use Viper's `null` — all null comparisons and null literals compile to
+`df$rt$nullValue()`.
+
+### Early alternatives
+
+Two alternative approaches were considered early in the project:
+
+1. **Parametric `Nullable[T]` domain**: wrap nullable values in a `Nullable[T]`
+   domain with `nullable_of`/`val_of_nullable` conversion functions. Rejected
+   because it requires boxing primitives onto the heap and permission reasoning
+   for field access. A prototype exists in `Domains/Nullable.vpr`.
+
+2. **Built-in Viper `null`**: use `null` as a `Ref` value directly. Rejected
+   because it conflates Viper's `null` (a `Ref` value) with Kotlin's `null`
+   (which can appear in any nullable type, including `Int?`), and still requires
+   boxing and permission reasoning.
+
+The chosen approach avoids both problems: `nullValue()` is a distinguished `Ref`
+constant in the domain, and the `nullable(t)` type wrapper handles subtyping
+without wrapping values.
+
+## Pretypes and types
+
+In the compiler plugin, nullability is separated into two layers:
+
+- A **pretype** (`PretypeEmbedding`) represents a Kotlin type without
+  nullability (or other flags). For example, `Int`, `Boolean`, `Foo`,
+  `(Int) -> Int` are all pretypes. Pretypes determine the structure of the
+  Viper encoding: injection functions, class predicates, field access, etc.
+
+- A **type** (`TypeEmbedding`) pairs a pretype with `TypeEmbeddingFlags`,
+  which currently contains a single `nullable` flag. The type determines the
+  full Viper encoding: runtime type assertions include `nullable()` when the
+  flag is set, and type invariants are wrapped with a non-null guard.
+
+This separation is intentional and enforced: `PretypeEmbedding` is not a subtype
+of `TypeEmbedding`, preventing one from being used where the other is expected.
+A pretype can be promoted to a type via `asTypeEmbedding()` (non-nullable) or
+`asNullableTypeEmbedding()`.
+
+The flags affect two things:
+
+1. **Runtime type**: `TypeEmbeddingFlags.adjustRuntimeType` wraps the pretype's
+   runtime type with `nullable()` when the flag is set.
+
+2. **Type invariants**: `TypeEmbeddingFlags.adjustInvariant` wraps invariants
+   with `IfNonNullInvariant`, adding `exp != nullValue() ==> invariant`. This
+   ensures class predicates and other invariants only apply when the value is
+   non-null.
 
 ## How nullability works
 

--- a/Design/nullability.md
+++ b/Design/nullability.md
@@ -4,159 +4,361 @@ Nullability is of direct interest since the Kotlin contracts allow to specify
 nullability checks (see [this KEEP][1]). Thus we need to model nullable types in
 Viper.
 
-This document presents two possible encoding of nullable types and discusses
-them.
-
-## First approach
-
-A simple first approach would be to just use the built-in null value of Viper.
-Let's see how this works on a very simple example:
-
-```kotlin
-fun null_check(x: Any?): Boolean {
-    if (x == null) {
-        return true
-    } else {
-        return false
-    }
-}
-```
-
-This function is a simple null check for which a contract can be written in
-order for the compiler to do better analysis.
-
-With the first approach this could be translated to Viper as follows:
-
-```viper
-field val: Ref
-
-method null_check2(x: Ref) returns (ret: Bool) 
-    requires x != null ==> acc(x.val)
-    requires x != null ==> acc(x.val)
-    ensures ret <==> x != null
-{
-    if (x == null) {
-        ret := false
-    } else {
-        ret := true
-    }
-}
-```
-
-This is somewhat straight-forward and let's one prove the relationship between
-the input and the output. One disadvantage is that access to the field needs to
-be restricted.
-
-There are, however, more drawbacks of this approach. One of which is modeling
-values that are not heap-based such as `Int`. Since these do not have a null
-value, they need to be boxed onto the stack. Then one needs to handles regular
-`Int`'s differently from `Int?`'s. This gets even more complicated when a
-nullable `Int` gets passed as a method parameter since this would mean it needs
-to be cloned because when the callee changes the value of the `Int?` (and thus
-its value on the heap) the `Int?` keeps in the caller must not be changed.
-
-A third argument as to why not go with this approach is that for the start of
-the project we want to reason about the heap as little as possible.
-
-Instead of dealing with all these complications we present a second more elegant
-representation.
-
+This document presents the encoding of nullable types used in the implementation.
+An earlier version of this document discussed two possible encodings; see git
+history for the original text.
 
 [1]: https://github.com/Kotlin/KEEP/blob/3490e847fe51aa6deb869654029a5a514638700e/proposals/kotlin-contracts.md
 
-## Second Approach
+## Overview
 
-Instead of using the built-in null value of Viper's `Ref` type, we define a new
-domain:
+The implementation uses a **unified `Ref` type** for all Kotlin values. Every
+Kotlin value — whether `Int`, `Boolean`, a class instance, or `null` — is
+represented as a Viper `Ref`. Type information is tracked separately via a
+`RuntimeTypeDomain` that provides:
+
+- A `RuntimeType` domain with subtyping (`isSubtype`), type-of (`typeOf`), and
+  nullability (`nullable`) functions.
+- A special `nullValue()` constant of type `Ref`.
+- Injection functions to convert between Viper primitive types and `Ref` (e.g.
+  `intToRef`/`intFromRef`).
+
+This avoids the complications of the originally proposed `Nullable[T]` parametric
+domain (boxing primitives, reasoning about permissions) and unifies nullable and
+non-nullable types into a single representation.
+
+## RuntimeTypeDomain
+
+The domain is defined in
+`SnaKt/formver.compiler-plugin/core/.../domains/RuntimeTypeDomain.kt`.
+
+### Core functions
 
 ```viper
-domain Nullable[T] {
-    function null_val(): Nullable[T]
-    function nullable_of(val: T): Nullable[T]
-    function val_of_nullable(x: Nullable[T]): T
+domain RuntimeType {
+    function isSubtype(t1: RuntimeType, t2: RuntimeType): Bool
+    function typeOf(r: Ref): RuntimeType
+    function nullable(t: RuntimeType): RuntimeType
 
-    axiom some_not_null {
-        forall x: T :: { nullable_of(x) }
-            nullable_of(x) != null_val()
-    }
-    axiom val_of_nullable_of_val {
-        forall x: T :: { val_of_nullable(nullable_of(x)) }
-            val_of_nullable(nullable_of(x)) == x
-    }
-    axiom nullable_of_val_of_nullable {
-        forall x: Nullable[T] :: { nullable_of(val_of_nullable(x)) }
-            x != null_val() ==> nullable_of(val_of_nullable(x)) == x
-    }
+    function nullValue(): Ref
+    function unitValue(): Ref
+
+    unique function intType(): RuntimeType
+    unique function boolType(): RuntimeType
+    unique function charType(): RuntimeType
+    unique function stringType(): RuntimeType
+    unique function unitType(): RuntimeType
+    unique function nothingType(): RuntimeType
+    unique function anyType(): RuntimeType
+    unique function functionType(): RuntimeType
+    // unique function *Type(): RuntimeType  — one per user-defined class
 }
 ```
 
-This domain models how nullable types behave. This allows for far more
-convenient translation and in addition one need not reason about permissions.
+### Key axioms
+
+**Subtyping** is a partial order (reflexive, transitive, antisymmetric):
 
 ```viper
-method null_check(x: Nullable[Ref]) returns (ret: Bool)
-    ensures ret <==> x != null_val()
-{
-    if (x == null_val()) {
-        ret := false
-    } else {
-        ret := true
-    }
+axiom subtype_reflexive { forall t :: isSubtype(t, t) }
+axiom subtype_transitive {
+    forall t1, t2, t3 ::
+        isSubtype(t1, t2) && isSubtype(t2, t3) ==> isSubtype(t1, t3)
+}
+axiom subtype_antisymmetric {
+    forall t1, t2 ::
+        isSubtype(t1, t2) && isSubtype(t2, t1) ==> t1 == t2
 }
 ```
 
-This also allows passing integers to other methods naturally without the
-aforementioned problems.
+**Nullable type** properties:
 
 ```viper
-method pass_nullable_parameter(x: Nullable[Int])
-    ensures x == old(x)
-{
-    some_method(x)
+// Wrapping is idempotent: Int?? is the same as Int?
+axiom nullable_idempotent {
+    forall t :: nullable(nullable(t)) == nullable(t)
+}
+
+// Non-nullable is a subtype of nullable
+axiom nullable_supertype {
+    forall t :: isSubtype(t, nullable(t))
+}
+
+// Subtyping lifts through nullable
+axiom nullable_preserves_subtype {
+    forall t1, t2 :: isSubtype(t1, t2) ==> isSubtype(nullable(t1), nullable(t2))
+}
+
+// Any? is the top type
+axiom nullable_any_supertype {
+    forall t :: isSubtype(t, nullable(anyType()))
+}
+
+// Nullable types are NOT subtypes of Any (this separates null from non-null)
+axiom any_not_nullable_type_level {
+    forall t :: !isSubtype(nullable(t), anyType())
 }
 ```
 
-For more examples see the the `nullability.kt` and `nullability.vpr` files the
-the `Examples` directory.
+**Null value** axioms:
 
-TODO: Look at cases where nullability can come from different sources like:
+```viper
+// null has type Nothing?
+axiom type_of_null {
+    isSubtype(typeOf(nullValue()), nullable(nothingType()))
+}
+
+// null is not a subtype of Any (value level)
+axiom any_not_nullable_value_level {
+    !isSubtype(typeOf(nullValue()), anyType())
+}
+```
+
+**Smart cast** axioms (these are what enable null-check reasoning):
+
+```viper
+// Value-level: if r has nullable type T?, then r is null or r has type T
+axiom null_smartcast_value_level {
+    forall r: Ref, t: RuntimeType ::
+        isSubtype(typeOf(r), nullable(t)) ==>
+        r == nullValue() || isSubtype(typeOf(r), t)
+}
+
+// Type-level: if t1 is a non-nullable type (subtype of Any) and also
+// subtype of T?, then t1 is a subtype of T
+axiom null_smartcast_type_level {
+    forall t1, t2 ::
+        isSubtype(t1, anyType()) && isSubtype(t1, nullable(t2)) ==>
+        isSubtype(t1, t2)
+}
+```
+
+**Other structural axioms:**
+
+```viper
+// Nothing has no inhabitants
+axiom nothing_empty { forall r :: !isSubtype(typeOf(r), nothingType()) }
+
+// Nothing is a subtype of every type (bottom type)
+axiom supertype_of_nothing { forall t :: isSubtype(nothingType(), t) }
+
+// Unit has exactly one value
+axiom type_of_unit { isSubtype(typeOf(unitValue()), unitType()) }
+axiom uniqueness_of_unit {
+    forall r :: isSubtype(typeOf(r), unitType()) ==> r == unitValue()
+}
+```
+
+## Injection functions
+
+Since all values are `Ref`, primitive types need injection/projection functions
+to convert between their Viper-native type and `Ref`. These are defined in
+`SnaKt/formver.compiler-plugin/core/.../domains/Injection.kt`.
+
+Each injection (e.g. for `Int`) provides:
+
+```viper
+function intToRef(v: Int): Ref
+function intFromRef(r: Ref): Int
+```
+
+With three axioms guaranteeing a bijection:
+
+```viper
+// Type preservation
+axiom { forall v: Int :: isSubtype(typeOf(intToRef(v)), intType()) }
+
+// Round-trip: native → Ref → native
+axiom { forall v: Int :: intFromRef(intToRef(v)) == v }
+
+// Round-trip: Ref → native → Ref (when type matches)
+axiom {
+    forall r: Ref ::
+        isSubtype(typeOf(r), intType()) ==> intToRef(intFromRef(r)) == r
+}
+```
+
+The same pattern applies to `Bool`, `Char` (represented as `Int` in Viper), and
+`String` (represented as `Seq[Int]`).
+
+Arithmetic and other operations on `Ref` are implemented as
+`InjectionImageFunction`s that unwrap arguments, apply the native Viper
+operation, and re-wrap the result.
+
+## Compiler-side representation
+
+In the compiler plugin, nullable types are represented by `TypeEmbedding`:
+
 ```kotlin
-typealias T = Int?
-typealias S = T?
+data class TypeEmbedding(val pretype: PretypeEmbedding, val flags: TypeEmbeddingFlags)
+data class TypeEmbeddingFlags(val nullable: Boolean)
 ```
 
-## Automatic conversion
+- `getNullable()` returns a copy with `nullable = true`.
+- `getNonNullable()` returns a copy with `nullable = false`.
+- `flags.adjustRuntimeType(runtimeType)` wraps with `nullable(...)` when the
+  flag is set.
 
-One problem that still needs to be solved in the conversion from nullable types
-to non-nullable types and back (both approaches face the same problem).
+Type invariants for nullable types are wrapped with `IfNonNullInvariant`, which
+generates `(exp != nullValue()) ==> invariant(exp)`. This ensures that
+invariants (e.g. class predicate access) are only required when the value is
+non-null.
 
-### From T to T?
+## Null literal
 
-In Kotlin code like `var x: Int? = 3` is totally valid. `x` is of type `Int?`,
-`3` is of type `Int` and since `Int` is a subtype of `Int?` it can be assigned.
-This is not so easy in Viper, however, as we have not solved subtyping yet. This
-means conversion functions need to be inserted as is `x := nullable_of(3)`. One
-could imagine that this could be handled even without solving the general case
-of subtyping. Whenever an expression of a nullable type is expected but a
-non-nullable expression is given, insert a conversion function.
-
-### From T? to T
-
-The reverse also needs to be handles. Especially interesting are the cases where
-the compiler does a smart cast as in:
+The `null` literal is represented as `NullLit` with type `Nothing?`:
 
 ```kotlin
-fun smart_cast(x: Int?): Int {
-    if (x == null) {
-        return 0
+data object NullLit : LiteralEmbedding {
+    override val type = buildType { isNullable = true; nothing() }
+    override fun toViper(ctx) = RuntimeTypeDomain.nullValue(...)
+}
+```
+
+In Viper output: `df$rt$nullValue()`.
+
+## Null checks and smart casts
+
+A null comparison `x == null` becomes `p$x == df$rt$nullValue()`. When this
+comparison appears as a condition in `if` or `when`, the Kotlin compiler produces
+a `FirSmartCastExpression` in the non-null branch.
+
+The plugin handles smart casts in `StmtConversionVisitor.visitSmartCastExpression`:
+
+- If the smart cast is from `T?` to `T` (only nullability changes), it produces
+  a simple `Cast` that changes the type without emitting Viper code.
+- If the smart cast changes the base type (e.g. `Any` to `Foo`), it inhales
+  the invariants of the new type.
+
+The SMT solver can then prove that in the non-null branch, `x != nullValue()`,
+and the `null_smartcast_value_level` axiom gives `isSubtype(typeOf(x), T)`.
+
+## Elvis operator (`?:`)
+
+`x ?: default` is translated to:
+
+```viper
+if (p$x != df$rt$nullValue()) {
+    ret := p$x
+} else {
+    ret := <default>
+}
+```
+
+This is implemented as an `Elvis` embedding that wraps the left operand in a
+null check via `notNullCmp()`.
+
+The special case `x ?: return e` (elvis with early return) is also supported:
+the right branch produces a return statement instead of an expression.
+
+## Safe call operator (`?.`)
+
+`x?.method()` is translated to:
+
+```viper
+if (p$x != df$rt$nullValue()) {
+    ret := method(p$x)
+} else {
+    ret := df$rt$nullValue()
+}
+```
+
+The receiver is evaluated once using a `share()` mechanism to prevent
+double-evaluation of side-effectful expressions. The result type is the nullable
+version of the method's return type.
+
+Safe call chains like `a?.b()?.c()` nest: each `?.` produces an `if` with the
+next `?.` in the non-null branch.
+
+## Examples
+
+### Null check with smart cast
+
+```kotlin
+fun smartcastReturn(n: Int?): Int =
+    if (n != null) n else 0
+```
+
+```viper
+method f$smartcastReturn$TF$NT$Int(p$n: Ref) returns (ret$0: Ref)
+    ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+{
+    inhale df$rt$isSubtype(df$rt$typeOf(p$n), df$rt$nullable(df$rt$intType()))
+    if (!(p$n == df$rt$nullValue())) {
+        ret$0 := p$n
     } else {
-    // Compiler infers that since x is not null it has to be of type Int.
-        return x
+        ret$0 := df$rt$intToRef(0)
     }
 }
 ```
 
-Here we need to extract this smart cast information from the compiler and also
-insert a explicit cast with `val_of_nullable`.
+### Elvis operator
 
-TODO: Look at other cases like `?.`, `?:`, `!!`, etc.
+```kotlin
+fun elvisOperator(x: Int?): Int {
+    return x ?: 3
+}
+```
+
+```viper
+method f$elvisOperator$TF$NT$Int(p$x: Ref) returns (ret$0: Ref)
+    ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$intType())
+{
+    inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
+    if (p$x != df$rt$nullValue()) {
+        ret$0 := p$x
+    } else {
+        ret$0 := df$rt$intToRef(3)
+    }
+}
+```
+
+### Safe call on a method
+
+```kotlin
+class Foo { fun f() {} }
+fun testSafeCall(foo: Foo?) = foo?.f()
+```
+
+```viper
+method f$testSafeCall$TF$NT$Foo(p$foo: Ref) returns (ret$0: Ref)
+    ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$unitType()))
+{
+    inhale df$rt$isSubtype(df$rt$typeOf(p$foo), df$rt$nullable(df$rt$c$Foo()))
+    inhale p$foo != df$rt$nullValue() ==> acc(p$c$Foo$shared(p$foo), wildcard)
+    if (p$foo != df$rt$nullValue()) {
+        var anon$0: Ref
+        anon$0 := f$c$Foo$f$TF$T$Foo(p$foo)
+        ret$0 := anon$0
+    } else {
+        ret$0 := df$rt$nullValue()
+    }
+}
+```
+
+### Nullable parameter passing
+
+```kotlin
+fun passNullableParameter(x: Int?): Int? {
+    useNullableTwice(x)
+    return x
+}
+```
+
+```viper
+method f$passNullableParameter$TF$NT$Int(p$x: Ref) returns (ret$0: Ref)
+    ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
+{
+    inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
+    var anon$0: Ref
+    anon$0 := f$useNullableTwice$TF$NT$Int(p$x)
+    ret$0 := p$x
+}
+```
+
+## Open questions
+
+- **Nullable type aliases**: Cases like `typealias T = Int?; typealias S = T?`
+  are handled by `nullable_idempotent` but haven't been tested explicitly.
+- **Not-null assertion (`!!`)**: The implementation status of this operator
+  should be verified.

--- a/Design/nullability.md
+++ b/Design/nullability.md
@@ -1,278 +1,177 @@
 # Nullability
 
 Nullability is of direct interest since the Kotlin contracts allow to specify
-nullability checks (see [this KEEP][1]). Thus we need to model nullable types in
-Viper.
-
-This document presents the encoding of nullable types used in the implementation.
-An earlier version of this document discussed two possible encodings; see git
-history for the original text.
+nullability checks (see [this KEEP][1]). We need to model nullable types in
+Viper so that the verifier can reason about null safety.
 
 [1]: https://github.com/Kotlin/KEEP/blob/3490e847fe51aa6deb869654029a5a514638700e/proposals/kotlin-contracts.md
 
-## Overview
+## Approaches considered
 
-The implementation uses a **unified `Ref` type** for all Kotlin values. Every
-Kotlin value — whether `Int`, `Boolean`, a class instance, or `null` — is
-represented as a Viper `Ref`. Type information is tracked separately via a
-`RuntimeTypeDomain` that provides:
+### Parametric `Nullable[T]` domain
 
-- A `RuntimeType` domain with subtyping (`isSubtype`), type-of (`typeOf`), and
-  nullability (`nullable`) functions.
-- A special `nullValue()` constant of type `Ref`.
-- Injection functions to convert between Viper primitive types and `Ref` (e.g.
-  `intToRef`/`intFromRef`).
-
-This avoids the complications of the originally proposed `Nullable[T]` parametric
-domain (boxing primitives, reasoning about permissions) and unifies nullable and
-non-nullable types into a single representation.
-
-## RuntimeTypeDomain
-
-The domain is defined in
-`SnaKt/formver.compiler-plugin/core/.../domains/RuntimeTypeDomain.kt`.
-
-### Core functions
+The first approach considered was a parametric Viper domain that wraps values:
 
 ```viper
-domain RuntimeType {
-    function isSubtype(t1: RuntimeType, t2: RuntimeType): Bool
-    function typeOf(r: Ref): RuntimeType
-    function nullable(t: RuntimeType): RuntimeType
+domain Nullable[T] {
+    function null_val(): Nullable[T]
+    function nullable_of(val: T): Nullable[T]
+    function val_of_nullable(x: Nullable[T]): T
 
-    function nullValue(): Ref
-    function unitValue(): Ref
-
-    unique function intType(): RuntimeType
-    unique function boolType(): RuntimeType
-    unique function charType(): RuntimeType
-    unique function stringType(): RuntimeType
-    unique function unitType(): RuntimeType
-    unique function nothingType(): RuntimeType
-    unique function anyType(): RuntimeType
-    unique function functionType(): RuntimeType
-    // unique function *Type(): RuntimeType  — one per user-defined class
+    axiom some_not_null {
+        forall x: T :: nullable_of(x) != null_val()
+    }
+    axiom val_of_nullable_of_val {
+        forall x: T :: val_of_nullable(nullable_of(x)) == x
+    }
+    axiom nullable_of_val_of_nullable {
+        forall x: Nullable[T] ::
+            x != null_val() ==> nullable_of(val_of_nullable(x)) == x
+    }
 }
 ```
 
-### Key axioms
+This gives a clean separation: `T` is the non-nullable type, `Nullable[T]` is
+the nullable wrapper, and `nullable_of`/`val_of_nullable` convert between them.
 
-**Subtyping** is a partial order (reflexive, transitive, antisymmetric):
+Drawbacks:
+- **Primitive boxing**: `Int` has no null value in Viper, so `Int?` would need
+  heap boxing. Passing `Int?` as a parameter then requires cloning to avoid
+  aliasing side effects.
+- **Permission reasoning**: accessing the wrapped value requires heap
+  permissions, adding complexity we want to avoid.
+- **Explicit conversion**: every nullable-to-non-nullable transition needs an
+  explicit `val_of_nullable` call, and vice versa.
+
+A prototype of this approach exists in `Domains/Nullable.vpr` (with a companion
+`Casting` domain for type conversions).
+
+### Built-in Viper `null`
+
+A simpler alternative: use Viper's built-in `null` reference directly. A
+function `null_check(x: Any?): Boolean` would translate to:
 
 ```viper
-axiom subtype_reflexive { forall t :: isSubtype(t, t) }
-axiom subtype_transitive {
-    forall t1, t2, t3 ::
-        isSubtype(t1, t2) && isSubtype(t2, t3) ==> isSubtype(t1, t3)
-}
-axiom subtype_antisymmetric {
-    forall t1, t2 ::
-        isSubtype(t1, t2) && isSubtype(t2, t1) ==> t1 == t2
+method null_check(x: Ref) returns (ret: Bool)
+    requires x != null ==> acc(x.val)
+    ensures ret <==> x != null
+```
+
+Drawbacks:
+- Requires permission reasoning for field access behind null checks.
+- Primitives still need boxing onto the heap.
+- Conflates Viper's `null` (a `Ref` value) with Kotlin's `null` (a value in
+  any nullable type).
+
+### Unified `Ref` with runtime type tracking (chosen)
+
+The approach adopted is to represent **all** Kotlin values as Viper `Ref`, with
+type information tracked through the [runtime type domain](runtime-type-domain.md).
+Nullable types are handled by a `nullable(t)` type wrapper in the domain,
+rather than by wrapping values.
+
+A nullable parameter `x: Int?` is encoded as:
+
+```viper
+method f(p$x: Ref) returns (ret$0: Ref)
+{
+    inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
+    ...
 }
 ```
 
-**Nullable type** properties:
+The value `p$x` is just a `Ref`. The `inhale` establishes that its runtime type
+is a subtype of `Int?`. No boxing, no permissions, no wrapper types.
+
+Advantages over the alternatives:
+- No boxing/unboxing for primitives — injection functions (`intToRef`/`intFromRef`)
+  handle the Viper-level representation transparently.
+- No permission reasoning for null checks — everything is value-level.
+- Smart casts fall out of axioms rather than requiring explicit conversions.
+- Nullable and non-nullable types share the same Viper type (`Ref`), so
+  parameter passing, assignment, and comparison work uniformly.
+
+## How nullability works
+
+### Null literal
+
+`null` in Kotlin becomes `df$rt$nullValue()`, a domain function returning `Ref`.
+Its type is `Nothing?`:
 
 ```viper
-// Wrapping is idempotent: Int?? is the same as Int?
-axiom nullable_idempotent {
-    forall t :: nullable(nullable(t)) == nullable(t)
-}
-
-// Non-nullable is a subtype of nullable
-axiom nullable_supertype {
-    forall t :: isSubtype(t, nullable(t))
-}
-
-// Subtyping lifts through nullable
-axiom nullable_preserves_subtype {
-    forall t1, t2 :: isSubtype(t1, t2) ==> isSubtype(nullable(t1), nullable(t2))
-}
-
-// Any? is the top type
-axiom nullable_any_supertype {
-    forall t :: isSubtype(t, nullable(anyType()))
-}
-
-// Nullable types are NOT subtypes of Any (this separates null from non-null)
-axiom any_not_nullable_type_level {
-    forall t :: !isSubtype(nullable(t), anyType())
-}
+axiom type_of_null { isSubtype(typeOf(nullValue()), nullable(nothingType())) }
 ```
 
-**Null value** axioms:
+Since `Nothing?` is a subtype of every nullable type (via `nullable_preserves_subtype`
+and `supertype_of_nothing`), `null` can be assigned to any `T?` variable.
+
+### Null checks
+
+`x == null` becomes `p$x == df$rt$nullValue()`. This is plain reference equality
+in Viper — no unwrapping needed.
+
+### Smart casts
+
+When a null check like `if (x != null)` guards a branch, the Kotlin compiler
+produces a `FirSmartCastExpression` that narrows `T?` to `T`. The plugin
+translates this as a no-op `Cast` (just changes the type annotation). The
+verifier can prove the narrowing via the `null_smartcast_value_level` axiom:
 
 ```viper
-// null has type Nothing?
-axiom type_of_null {
-    isSubtype(typeOf(nullValue()), nullable(nothingType()))
-}
-
-// null is not a subtype of Any (value level)
-axiom any_not_nullable_value_level {
-    !isSubtype(typeOf(nullValue()), anyType())
-}
-```
-
-**Smart cast** axioms (these are what enable null-check reasoning):
-
-```viper
-// Value-level: if r has nullable type T?, then r is null or r has type T
+// If r has type T?, then either r is null or r has type T
 axiom null_smartcast_value_level {
     forall r: Ref, t: RuntimeType ::
         isSubtype(typeOf(r), nullable(t)) ==>
         r == nullValue() || isSubtype(typeOf(r), t)
 }
-
-// Type-level: if t1 is a non-nullable type (subtype of Any) and also
-// subtype of T?, then t1 is a subtype of T
-axiom null_smartcast_type_level {
-    forall t1, t2 ::
-        isSubtype(t1, anyType()) && isSubtype(t1, nullable(t2)) ==>
-        isSubtype(t1, t2)
-}
 ```
 
-**Other structural axioms:**
+In the non-null branch, the solver knows `r != nullValue()`, so it concludes
+`isSubtype(typeOf(r), t)` — the smart cast holds.
+
+### Nullable type invariants
+
+When a type is nullable, its invariants (e.g. class predicate access) are
+wrapped with an implication: the invariant only applies when the value is
+non-null. For example, a `Foo?` parameter inhales:
 
 ```viper
-// Nothing has no inhabitants
-axiom nothing_empty { forall r :: !isSubtype(typeOf(r), nothingType()) }
-
-// Nothing is a subtype of every type (bottom type)
-axiom supertype_of_nothing { forall t :: isSubtype(nothingType(), t) }
-
-// Unit has exactly one value
-axiom type_of_unit { isSubtype(typeOf(unitValue()), unitType()) }
-axiom uniqueness_of_unit {
-    forall r :: isSubtype(typeOf(r), unitType()) ==> r == unitValue()
-}
+inhale p$foo != df$rt$nullValue() ==> acc(p$c$Foo$shared(p$foo), wildcard)
 ```
 
-## Injection functions
+### Elvis operator (`?:`)
 
-Since all values are `Ref`, primitive types need injection/projection functions
-to convert between their Viper-native type and `Ref`. These are defined in
-`SnaKt/formver.compiler-plugin/core/.../domains/Injection.kt`.
-
-Each injection (e.g. for `Int`) provides:
-
-```viper
-function intToRef(v: Int): Ref
-function intFromRef(r: Ref): Int
-```
-
-With three axioms guaranteeing a bijection:
-
-```viper
-// Type preservation
-axiom { forall v: Int :: isSubtype(typeOf(intToRef(v)), intType()) }
-
-// Round-trip: native → Ref → native
-axiom { forall v: Int :: intFromRef(intToRef(v)) == v }
-
-// Round-trip: Ref → native → Ref (when type matches)
-axiom {
-    forall r: Ref ::
-        isSubtype(typeOf(r), intType()) ==> intToRef(intFromRef(r)) == r
-}
-```
-
-The same pattern applies to `Bool`, `Char` (represented as `Int` in Viper), and
-`String` (represented as `Seq[Int]`).
-
-Arithmetic and other operations on `Ref` are implemented as
-`InjectionImageFunction`s that unwrap arguments, apply the native Viper
-operation, and re-wrap the result.
-
-## Compiler-side representation
-
-In the compiler plugin, nullable types are represented by `TypeEmbedding`:
-
-```kotlin
-data class TypeEmbedding(val pretype: PretypeEmbedding, val flags: TypeEmbeddingFlags)
-data class TypeEmbeddingFlags(val nullable: Boolean)
-```
-
-- `getNullable()` returns a copy with `nullable = true`.
-- `getNonNullable()` returns a copy with `nullable = false`.
-- `flags.adjustRuntimeType(runtimeType)` wraps with `nullable(...)` when the
-  flag is set.
-
-Type invariants for nullable types are wrapped with `IfNonNullInvariant`, which
-generates `(exp != nullValue()) ==> invariant(exp)`. This ensures that
-invariants (e.g. class predicate access) are only required when the value is
-non-null.
-
-## Null literal
-
-The `null` literal is represented as `NullLit` with type `Nothing?`:
-
-```kotlin
-data object NullLit : LiteralEmbedding {
-    override val type = buildType { isNullable = true; nothing() }
-    override fun toViper(ctx) = RuntimeTypeDomain.nullValue(...)
-}
-```
-
-In Viper output: `df$rt$nullValue()`.
-
-## Null checks and smart casts
-
-A null comparison `x == null` becomes `p$x == df$rt$nullValue()`. When this
-comparison appears as a condition in `if` or `when`, the Kotlin compiler produces
-a `FirSmartCastExpression` in the non-null branch.
-
-The plugin handles smart casts in `StmtConversionVisitor.visitSmartCastExpression`:
-
-- If the smart cast is from `T?` to `T` (only nullability changes), it produces
-  a simple `Cast` that changes the type without emitting Viper code.
-- If the smart cast changes the base type (e.g. `Any` to `Foo`), it inhales
-  the invariants of the new type.
-
-The SMT solver can then prove that in the non-null branch, `x != nullValue()`,
-and the `null_smartcast_value_level` axiom gives `isSubtype(typeOf(x), T)`.
-
-## Elvis operator (`?:`)
-
-`x ?: default` is translated to:
+`x ?: default` becomes a conditional on whether `x` is null:
 
 ```viper
 if (p$x != df$rt$nullValue()) {
-    ret := p$x
+    ret$0 := p$x
 } else {
-    ret := <default>
+    ret$0 := <default>
 }
 ```
 
-This is implemented as an `Elvis` embedding that wraps the left operand in a
-null check via `notNullCmp()`.
+The special case `x ?: return e` (early return in the null branch) is also
+supported.
 
-The special case `x ?: return e` (elvis with early return) is also supported:
-the right branch produces a return statement instead of an expression.
+### Safe call operator (`?.`)
 
-## Safe call operator (`?.`)
-
-`x?.method()` is translated to:
+`x?.method()` becomes:
 
 ```viper
 if (p$x != df$rt$nullValue()) {
-    ret := method(p$x)
+    ret$0 := method(p$x)
 } else {
-    ret := df$rt$nullValue()
+    ret$0 := df$rt$nullValue()
 }
 ```
 
-The receiver is evaluated once using a `share()` mechanism to prevent
-double-evaluation of side-effectful expressions. The result type is the nullable
-version of the method's return type.
-
-Safe call chains like `a?.b()?.c()` nest: each `?.` produces an `if` with the
-next `?.` in the non-null branch.
+The receiver is evaluated once via a sharing mechanism to prevent
+double-evaluation. Safe call chains (`a?.b()?.c()`) nest naturally.
 
 ## Examples
 
-### Null check with smart cast
+### Smart cast after null check
 
 ```kotlin
 fun smartcastReturn(n: Int?): Int =
@@ -292,12 +191,14 @@ method f$smartcastReturn$TF$NT$Int(p$n: Ref) returns (ret$0: Ref)
 }
 ```
 
+Note that `p$n` is used directly as `ret$0` in the non-null branch — no
+unwrapping call. The postcondition `isSubtype(typeOf(ret$0), intType())` is
+proven by the solver using `null_smartcast_value_level`.
+
 ### Elvis operator
 
 ```kotlin
-fun elvisOperator(x: Int?): Int {
-    return x ?: 3
-}
+fun elvisOperator(x: Int?): Int = x ?: 3
 ```
 
 ```viper
@@ -336,29 +237,5 @@ method f$testSafeCall$TF$NT$Foo(p$foo: Ref) returns (ret$0: Ref)
 }
 ```
 
-### Nullable parameter passing
-
-```kotlin
-fun passNullableParameter(x: Int?): Int? {
-    useNullableTwice(x)
-    return x
-}
-```
-
-```viper
-method f$passNullableParameter$TF$NT$Int(p$x: Ref) returns (ret$0: Ref)
-    ensures df$rt$isSubtype(df$rt$typeOf(ret$0), df$rt$nullable(df$rt$intType()))
-{
-    inhale df$rt$isSubtype(df$rt$typeOf(p$x), df$rt$nullable(df$rt$intType()))
-    var anon$0: Ref
-    anon$0 := f$useNullableTwice$TF$NT$Int(p$x)
-    ret$0 := p$x
-}
-```
-
-## Open questions
-
-- **Nullable type aliases**: Cases like `typealias T = Int?; typealias S = T?`
-  are handled by `nullable_idempotent` but haven't been tested explicitly.
-- **Not-null assertion (`!!`)**: The implementation status of this operator
-  should be verified.
+Note the guarded `inhale` for the class predicate — it only applies when
+`p$foo` is non-null.

--- a/Design/runtime-type-domain.md
+++ b/Design/runtime-type-domain.md
@@ -1,0 +1,178 @@
+# Runtime Type Domain
+
+The runtime type domain is the backbone of SnaKt's Viper encoding. It provides
+a unified representation of all Kotlin values as Viper `Ref`, with type
+information tracked separately through domain functions and axioms.
+
+This document describes the domain as implemented in
+`formver.compiler-plugin/core/.../domains/RuntimeTypeDomain.kt`.
+
+## Motivation
+
+Kotlin has a rich type system with nullable types, class hierarchies, generics,
+and primitive types. Viper's built-in type system is much simpler. Rather than
+encoding each Kotlin type as a separate Viper type (which would require boxing,
+casting, and permission reasoning), all Kotlin values are represented as `Ref`
+with a separate domain tracking type information.
+
+This design was chosen over alternatives like parametric `Nullable[T]` domains
+(see [nullability](nullability.md)) because it:
+- Avoids boxing/unboxing complexity for primitives
+- Eliminates permission reasoning for nullable values
+- Provides a single uniform encoding for subtyping, casting, and null checks
+- Enables smart casts via axioms rather than explicit conversions
+
+Earlier prototypes of a multi-domain approach can be found in `Domains/*.vpr`.
+
+## Domain structure
+
+```viper
+domain RuntimeType {
+    // Subtyping and type tracking
+    function isSubtype(t1: RuntimeType, t2: RuntimeType): Bool
+    function typeOf(r: Ref): RuntimeType
+    function nullable(t: RuntimeType): RuntimeType
+
+    // Special values
+    function nullValue(): Ref
+    function unitValue(): Ref
+
+    // Built-in type constants (unique ensures distinctness)
+    unique function intType(): RuntimeType
+    unique function boolType(): RuntimeType
+    unique function charType(): RuntimeType
+    unique function stringType(): RuntimeType
+    unique function unitType(): RuntimeType
+    unique function nothingType(): RuntimeType
+    unique function anyType(): RuntimeType
+    unique function functionType(): RuntimeType
+
+    // One per user-defined class:
+    // unique function <className>(): RuntimeType
+}
+```
+
+## Subtyping axioms
+
+Subtyping is a partial order:
+
+```viper
+axiom subtype_reflexive    { forall t :: isSubtype(t, t) }
+axiom subtype_transitive   { forall t1, t2, t3 ::
+    isSubtype(t1, t2) && isSubtype(t2, t3) ==> isSubtype(t1, t3) }
+axiom subtype_antisymmetric { forall t1, t2 ::
+    isSubtype(t1, t2) && isSubtype(t2, t1) ==> t1 == t2 }
+```
+
+All non-nullable types are subtypes of `Any`:
+
+```viper
+axiom { isSubtype(intType(), anyType()) }
+axiom { isSubtype(boolType(), anyType()) }
+// ... etc. for all built-in and user-defined types
+```
+
+`Nothing` is the bottom type:
+
+```viper
+axiom supertype_of_nothing { forall t :: isSubtype(nothingType(), t) }
+axiom nothing_empty        { forall r :: !isSubtype(typeOf(r), nothingType()) }
+```
+
+## Nullable type axioms
+
+See [nullability](nullability.md) for the design context. The key axioms:
+
+```viper
+axiom nullable_idempotent       { forall t :: nullable(nullable(t)) == nullable(t) }
+axiom nullable_supertype        { forall t :: isSubtype(t, nullable(t)) }
+axiom nullable_preserves_subtype { forall t1, t2 ::
+    isSubtype(t1, t2) ==> isSubtype(nullable(t1), nullable(t2)) }
+axiom nullable_any_supertype    { forall t :: isSubtype(t, nullable(anyType())) }
+axiom any_not_nullable_type_level { forall t :: !isSubtype(nullable(t), anyType()) }
+```
+
+Null value:
+
+```viper
+axiom type_of_null               { isSubtype(typeOf(nullValue()), nullable(nothingType())) }
+axiom any_not_nullable_value_level { !isSubtype(typeOf(nullValue()), anyType()) }
+```
+
+Smart cast axioms (enable reasoning after null checks):
+
+```viper
+axiom null_smartcast_value_level { forall r, t ::
+    isSubtype(typeOf(r), nullable(t)) ==> r == nullValue() || isSubtype(typeOf(r), t) }
+axiom null_smartcast_type_level  { forall t1, t2 ::
+    isSubtype(t1, anyType()) && isSubtype(t1, nullable(t2)) ==> isSubtype(t1, t2) }
+```
+
+## Unit axioms
+
+```viper
+axiom type_of_unit      { isSubtype(typeOf(unitValue()), unitType()) }
+axiom uniqueness_of_unit { forall r ::
+    isSubtype(typeOf(r), unitType()) ==> r == unitValue() }
+```
+
+## Injection functions
+
+Since all values are `Ref`, primitive types need bijective mappings. Each
+injection provides a `toRef`/`fromRef` pair with three axioms:
+
+```viper
+// Example for Int:
+function intToRef(v: Int): Ref
+function intFromRef(r: Ref): Int
+
+axiom { forall v: Int :: isSubtype(typeOf(intToRef(v)), intType()) }
+axiom { forall v: Int :: intFromRef(intToRef(v)) == v }
+axiom { forall r: Ref :: isSubtype(typeOf(r), intType()) ==> intToRef(intFromRef(r)) == r }
+```
+
+Available injections:
+- `Int` <-> `Ref` (Viper `Int`)
+- `Bool` <-> `Ref` (Viper `Bool`)
+- `Char` <-> `Ref` (Viper `Int` — characters as code points)
+- `String` <-> `Ref` (Viper `Seq[Int]`)
+
+Arithmetic and other operations are implemented as `InjectionImageFunction`s:
+Viper functions that unwrap `Ref` arguments via `fromRef`, apply the native
+operation, and re-wrap via `toRef`.
+
+## User-defined class types
+
+Each class in the program gets a unique type function added to the domain:
+
+```viper
+unique function c$Foo(): RuntimeType
+```
+
+Subtype relationships between classes are also added as axioms based on the
+class hierarchy.
+
+## Compiler-side representation
+
+`TypeEmbedding` pairs a `PretypeEmbedding` (the base type) with
+`TypeEmbeddingFlags` (currently just a `nullable` boolean):
+
+```kotlin
+data class TypeEmbedding(val pretype: PretypeEmbedding, val flags: TypeEmbeddingFlags)
+data class TypeEmbeddingFlags(val nullable: Boolean)
+```
+
+`flags.adjustRuntimeType(exp)` wraps with `nullable(...)` when the flag is set.
+`flags.adjustInvariant(inv)` wraps with `IfNonNullInvariant` — generating
+`(x != nullValue()) ==> invariant(x)`.
+
+## Naming convention
+
+In generated Viper output, domain functions are prefixed with `df$rt$`:
+- `df$rt$isSubtype(...)`, `df$rt$typeOf(...)`, `df$rt$nullable(...)`
+- `df$rt$nullValue()`, `df$rt$unitValue()`
+- `df$rt$intToRef(...)`, `df$rt$intFromRef(...)`
+- `df$rt$intType()`, `df$rt$c$Foo()`, etc.
+
+Special arithmetic/comparison functions use the `sp$` prefix:
+- `sp$plusInts(...)`, `sp$minusInts(...)`, `sp$notBool(...)`, etc.


### PR DESCRIPTION
## Summary
Rewrites `Design/nullability.md` and adds `Design/runtime-type-domain.md`.

Key changes to nullability.md:
- Leads with the chosen encoding (unified Ref + domain-level `nullable(t)` + `nullValue()`) rather than presenting three approaches as peers
- Clarifies that `nullValue()` is a domain function, not Viper's built-in `null`
- Adds section on pretype vs type: how the compiler separates base types (`PretypeEmbedding`) from nullability flags (`TypeEmbeddingFlags`), and how the flag affects runtime type assertions and type invariants
- Demotes rejected alternatives (parametric `Nullable[T]`, built-in Viper null) to a brief subsection
- Documents null literal, null checks, smart casts, nullable invariants, elvis, and safe call with Viper examples

runtime-type-domain.md is a new companion doc covering the general RuntimeTypeDomain encoding.

## Test plan
- [x] Verified Viper examples against actual golden file output

🤖 Generated with [Claude Code](https://claude.com/claude-code)