### PR TITLE
[claude-experiments] Update calls-in-place doc to reflect implementation status

### DIFF
--- a/Design/calls-in-place.md
+++ b/Design/calls-in-place.md
@@ -1,49 +1,117 @@
 # `callsInPlace` contract
 
-The `callsInPlace` construct applies to a parameter `fo` of function type and guarantees two properties:
-1. `fo` is not stored past the duration of the function call; we refer to this as that the variable _does not escape_.
-2. (Optionally) `fo` is called a specific number of times: once, at least once, or at most once.
+The `callsInPlace` construct applies to a parameter `fo` of function type and
+guarantees two properties:
+1. `fo` is not stored past the duration of the function call; we refer to this
+   as that the variable _does not escape_.
+2. (Optionally) `fo` is called a specific number of times: once, at least once,
+   or at most once.
 
-We can model objects of function type as references with an associated `num_calls` field that is
-incremented every time the function object is invoked.
+## Implementation status
 
-We use the encoding described in `function-as-parameters.md` for objects of function type.
+**`callsInPlace` is currently not encoded.** The contract visitor recognises
+the FIR node (`KtCallsEffectDeclaration`) but returns `true`, which is then
+filtered out by `getPostconditions`. No Viper constraints are generated.
 
-## Escape
+Inline functions sidestep the issue: their lambda bodies are inlined directly
+into the caller, so the callsInPlace guarantee is trivially satisfied by
+construction. The contract only matters for non-inline higher-order functions,
+where function objects are currently represented as havoc'd references (see
+[function objects](#function-object-encoding) below).
 
-Instead of marking objects that may not escape, we can mark objects that may escape, treating that as a
-precondition for calling functions from which escape is possible.  This precondition does not involve
-ownership, and so can be modelled with an opaque Boolean-valued function.
+## Intended encoding
 
-We need to choose what types do and do not require escape permissions.  There are two possibilities:
-1. Annotate only function objects.  This may mean that casting function objects to `Any` (if Kotlin
-   even allows that?) would require a may-escape precondition.
-2. Annotate all objects.  This involves getting duplicability information for fields; it is unclear
-   how to do this.
+We can model objects of function type as references with an associated
+`num_calls` field that is incremented every time the function object is invoked.
+See [functions-as-parameters](functions-as-parameters.md) for the full encoding.
 
-It seems like option 1 is likely to be a better trade-off as real-life examples don't generally involve
-casting the function objects.
+### Escape tracking
 
-## Number of calls
+Instead of marking objects that may not escape, we can mark objects that _may_
+escape, treating that as a precondition for calling functions from which escape
+is possible. This precondition does not involve ownership, and so can be
+modelled with an opaque Boolean-valued function.
 
-The calls to `fo` should be tracked via a counter to allow us to determine the number of times that
-it is called.  We track this using a counter on the function object.
+We need to choose what types do and do not require escape permissions:
+1. Annotate only function objects. This may mean that casting function objects
+   to `Any` would require a may-escape precondition.
+2. Annotate all objects. This involves getting duplicability information for
+   fields; it is unclear how to do this.
 
-A non-obvious difficulty here is that the counter is monotonically increasing, which we need to make
-sure to specify at all points (e.g. loop invariants).
+Option 1 is likely a better trade-off as real-life examples don't generally
+involve casting function objects.
 
-Note that due to the partial correctness property of Viper, a possible false negative occurs in the
-following:
+### Invocation counting
+
+The calls to `fo` should be tracked via a counter to allow us to determine
+the number of times it is called. We track this using a counter on the
+function object:
+
+```viper
+field FunctionObject_num_calls: Int
+predicate FunctionObject(this: Ref) {
+  acc(this.FunctionObject_num_calls)
+}
+
+method invokeFunctionObject(this: Ref)
+  requires FunctionObject(this)
+  ensures FunctionObject(this)
+  ensures FunctionObject_get_num_calls(this) == old(FunctionObject_get_num_calls(this)) + 1
+```
+
+The invocation kind maps to postconditions on the counter:
+- `EXACTLY_ONCE`: `num_calls == old(num_calls) + 1`
+- `AT_LEAST_ONCE`: `num_calls >= old(num_calls) + 1`
+- `AT_MOST_ONCE`: `num_calls <= old(num_calls) + 1`
+
+A non-obvious difficulty is that the counter is monotonically increasing,
+which we need to specify at all points (e.g. loop invariants).
+
+### Partial correctness caveat
+
+Due to the partial correctness property of Viper, a false negative occurs in:
 
 ```kotlin
 fun foo(fo: () -> Unit) {
-  contract {
-    callsInPlace(fo, EXACTLY_ONCE)
-  }
-  while (true) {}
+    contract { callsInPlace(fo, EXACTLY_ONCE) }
+    while (true) {}
 }
 ```
 
-We could partially mitigate this by ending the function with `refute false`, which would ensure that
-Viper cannot verify that `foo` does not terminate.  However, short of requiring a termination proof
-we cannot avoid this entirely.
+We could partially mitigate this by ending the function with `refute false`,
+which would ensure that Viper cannot verify that `foo` does not terminate.
+However, short of requiring a termination proof we cannot avoid this entirely.
+
+## Function object encoding
+
+Currently, non-inline function object calls produce a **havoc**: the result
+is a fresh anonymous variable with only its type constrained. Arguments
+passed to the function object are evaluated but their values are discarded.
+
+For example, `g(true, 0)` where `g: (Boolean, Int) -> Int` produces:
+
+```viper
+var anon$0: Ref
+inhale df$rt$isSubtype(df$rt$typeOf(p$g), df$rt$functionType())
+inhale df$rt$isSubtype(df$rt$typeOf(anon$0), df$rt$intType())
+ret$0 := anon$0
+```
+
+This means:
+- The verifier cannot reason about the relationship between arguments and
+  return value.
+- Postconditions that depend on function object behaviour cannot be proven.
+- Any property that the function object is supposed to establish must be
+  assumed rather than verified.
+
+Creating actual function objects (with predicate, counter, and parameter
+passing) is blocked on the TODO in `LambdaExp.toViperStoringIn`.
+
+## What works today
+
+Inline functions with lambdas work correctly because the lambda body is
+substituted directly into the caller. The `callsInPlace(EXACTLY_ONCE)`
+contract on stdlib functions like `run`, `let`, `with`, `also`, `apply`
+is irrelevant — these are all inline, so the body is always inlined exactly
+once. Verification of these patterns is tested in
+`verification/inlining/` and `verification/stdlib_replacement_tests.kt`.

--- a/Design/calls-in-place.md
+++ b/Design/calls-in-place.md
@@ -30,14 +30,29 @@ where function objects are currently represented as havoc'd references (see
 
 ## Intended encoding
 
-We can model objects of function type as references with an associated
-`num_calls` field that is incremented every time the function object is invoked.
-See [functions-as-parameters](functions-as-parameters.md) for the full encoding.
+Since we trust the `callsInPlace` declaration, the encoding does not need to
+track or verify invocation counts. Instead, we assume the declared guarantees
+at the call site.
 
-Note: the encoding below is designed to _assume_ the declared invocation
-guarantees in calling code, not to verify the callee's implementation.
+For `EXACTLY_ONCE`, the caller can assume:
+- The lambda body executes exactly once.
+- Variables assigned in the lambda are definitely assigned after the call.
+- Side effects of the lambda occur exactly once.
+
+For `AT_LEAST_ONCE` and `AT_MOST_ONCE`, weaker assumptions apply accordingly.
+
+The main challenge is encoding this for non-inline functions, where the lambda
+body is not substituted into the caller. We need a function object encoding
+that lets the caller assume the effects of the lambda body have been applied
+the declared number of times. See
+[functions-as-parameters](functions-as-parameters.md) for the function object
+encoding.
 
 ### Escape tracking
+
+The non-escape guarantee (property 1) means the function object is not stored
+past the call. This is relevant for ownership and permission reasoning: the
+caller retains full ownership of any captured state.
 
 Instead of marking objects that may not escape, we can mark objects that _may_
 escape, treating that as a precondition for calling functions from which escape
@@ -52,47 +67,6 @@ We need to choose what types do and do not require escape permissions:
 
 Option 1 is likely a better trade-off as real-life examples don't generally
 involve casting function objects.
-
-### Invocation counting
-
-The calls to `fo` should be tracked via a counter to allow us to determine
-the number of times it is called. We track this using a counter on the
-function object:
-
-```viper
-field FunctionObject_num_calls: Int
-predicate FunctionObject(this: Ref) {
-  acc(this.FunctionObject_num_calls)
-}
-
-method invokeFunctionObject(this: Ref)
-  requires FunctionObject(this)
-  ensures FunctionObject(this)
-  ensures FunctionObject_get_num_calls(this) == old(FunctionObject_get_num_calls(this)) + 1
-```
-
-The invocation kind maps to postconditions on the counter:
-- `EXACTLY_ONCE`: `num_calls == old(num_calls) + 1`
-- `AT_LEAST_ONCE`: `num_calls >= old(num_calls) + 1`
-- `AT_MOST_ONCE`: `num_calls <= old(num_calls) + 1`
-
-A non-obvious difficulty is that the counter is monotonically increasing,
-which we need to specify at all points (e.g. loop invariants).
-
-### Partial correctness caveat
-
-Due to the partial correctness property of Viper, a false negative occurs in:
-
-```kotlin
-fun foo(fo: () -> Unit) {
-    contract { callsInPlace(fo, EXACTLY_ONCE) }
-    while (true) {}
-}
-```
-
-We could partially mitigate this by ending the function with `refute false`,
-which would ensure that Viper cannot verify that `foo` does not terminate.
-However, short of requiring a termination proof we cannot avoid this entirely.
 
 ## Function object encoding
 
@@ -116,8 +90,8 @@ This means:
 - Any property that the function object is supposed to establish must be
   assumed rather than verified.
 
-Creating actual function objects (with predicate, counter, and parameter
-passing) is blocked on the TODO in `LambdaExp.toViperStoringIn`.
+Creating actual function objects (with predicate and parameter passing) is
+blocked on the TODO in `LambdaExp.toViperStoringIn`.
 
 ## What works today
 

--- a/Design/calls-in-place.md
+++ b/Design/calls-in-place.md
@@ -7,6 +7,15 @@ guarantees two properties:
 2. (Optionally) `fo` is called a specific number of times: once, at least once,
    or at most once.
 
+## Scope
+
+Verifying the _correctness_ of `callsInPlace` declarations is a non-goal for
+this project. That is, we do not check that a function's implementation actually
+calls `fo` the declared number of times. Instead, the goal is to _use_
+`callsInPlace` information to improve verification of calling code — for
+example, knowing that a lambda is called exactly once lets us reason about
+definite assignment and variable initialization in the caller.
+
 ## Implementation status
 
 **`callsInPlace` is currently not encoded.** The contract visitor recognises
@@ -24,6 +33,9 @@ where function objects are currently represented as havoc'd references (see
 We can model objects of function type as references with an associated
 `num_calls` field that is incremented every time the function object is invoked.
 See [functions-as-parameters](functions-as-parameters.md) for the full encoding.
+
+Note: the encoding below is designed to _assume_ the declared invocation
+guarantees in calling code, not to verify the callee's implementation.
 
 ### Escape tracking
 


### PR DESCRIPTION
## Summary
- Rewrites `Design/calls-in-place.md` to document that callsInPlace is **not currently encoded** (contract visitor returns `true`, filtered out by `getPostconditions`)
- Adds scope clarification: verifying correctness of callsInPlace declarations is a **non-goal** — the project aims to _use_ the declared guarantees to improve verification of calling code
- Removes the invocation counting encoding (num_calls counters, partial correctness caveat) since it was oriented toward verification, which is out of scope
- Rewrites the intended encoding to focus on assuming declared guarantees at call sites
- Adds section on current function object encoding (havoc: fresh variable, arguments discarded)
- Documents what works today (inline functions only — body substituted directly, contract irrelevant)

## Context
Part of the design accuracy audit. The previous version described an invocation counting encoding as if it were the plan. Since verifying callsInPlace correctness is a non-goal, that encoding doesn't apply. The rewrite focuses on what matters: using the guarantees in calling code.

## Test plan
- [x] Verified generated Viper matches documented behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)